### PR TITLE
Better handling of oauth_callback parameter to requestToken endpoint

### DIFF
--- a/linkedin.py
+++ b/linkedin.py
@@ -44,9 +44,6 @@ class LinkedinAPI(object):
         self.access_token_url = 'https://api.linkedin.com/uas/oauth/accessToken'
         self.authorize_url = 'https://api.linkedin.com/uas/oauth/authorize'
 
-        if self.callback_url:
-            self.request_token_url = '%s?oauth_callback=%s' % (self.request_token_url, self.callback_url)
-
         self.api_base = 'http://api.linkedin.com'
         self.api_version = 'v1'
         self.api_url = '%s/%s/' % (self.api_base, self.api_version)
@@ -92,7 +89,8 @@ class LinkedinAPI(object):
             print auth_url
         """
 
-        resp, content = self.client.request(self.request_token_url, 'GET')
+        body = urllib.urlencode({'oauth_callback':self.callback_url}) if self.callback_url else None
+        resp, content = self.client.request(self.request_token_url, 'POST', body=body)
 
         status = int(resp['status'])
         if status != 200:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='linkedin',
-    version='0.1.2',
+    version='0.1.2.circleup-patch',
     install_requires=['httplib2', 'oauth2', 'simplejson'],
     author='Mike Helmick',
     author_email='mikehelmick@me.com',


### PR DESCRIPTION
Hi Michael,

I ran into an issue in using this library to call the requestToken endpoint with an oauth_callback URL that itself contains parameters. Since the existing code is just doing a GET against the requestToken endpoint and appending oauth_callback as a URL parameter, when the callback URL itself has parameters, they get mixed up. So one fix would just be to percent-encode this; but since the LinkedIn Authentication docs suggest POST is the preferable method, I updated the code to send the oauth_callback in the POST body instead, and this works for me now.

By the way, ignore the other pull request I sent before, this one replaces it.
