### PR TITLE
Added changes that fixed issues with my implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Hope this documentation explains everything you need to get started. Any questio
 
 #Install through pip...
 ```
-pip install linkedin
+pip install linkedin==0.1.3
 ```
 
 #Import LinkedIn library

--- a/linkedin.py
+++ b/linkedin.py
@@ -43,7 +43,9 @@ class LinkedinAPI(object):
         # Authentication URLs
         self.request_token_url = 'https://api.linkedin.com/uas/oauth/requestToken'
         self.access_token_url = 'https://api.linkedin.com/uas/oauth/accessToken'
-        self.authorize_url = 'https://api.linkedin.com/uas/oauth/authorize'
+		# Authentication page in http://developer.linkedin.com/documents/authentication states that 
+		# endpoint is the following not the previous url used.
+        self.authorize_url = 'https://api.linkedin.com/uas/oauth/authenticate'
 
         if self.callback_url:
             self.request_token_url = '%s?oauth_callback=%s' % (self.request_token_url, self.callback_url)

--- a/linkedin.py
+++ b/linkedin.py
@@ -101,7 +101,7 @@ class LinkedinAPI(object):
             print auth_url
         """
 
-        resp, content = self.client.request(self.request_token_url, 'GET')
+        resp, content = self.client.request(self.request_token_url, 'POST')
 
         status = int(resp['status'])
         if status != 200:
@@ -126,7 +126,7 @@ class LinkedinAPI(object):
             oauth_token_secret = authorized_tokens['oauth_token_secret']
         """
 
-        resp, content = self.client.request('%s?oauth_verifier=%s' % (self.access_token_url, oauth_verifier), 'GET')
+        resp, content = self.client.request('%s?oauth_verifier=%s' % (self.access_token_url, oauth_verifier), 'POST')
         return dict(parse_qsl(content))
 
     def api_request(self, endpoint, method='GET', fields='', params={}):


### PR DESCRIPTION
Hello Michael
1. README.md states that for installation, you have to run pip install linkedin -- however if someone wishes to add scope to the request, in version 0.1.2, permissions is not part of LinkedinAPI::**init**() property list. To fix this, I added a minor text change in the README.md file. The user should now call, pip install linkedin==0.1.3. I noted that when I called pip install linkedin after someone else had bumped the version 0.1.3, pip was still installing version 0.1.2.
2. When trying to retrieve a requestToken and then accessToken, we were doing this by 'GET' method. However, documentation in http://developer.linkedin.com/documents/authentication states that these calls need to be of type 'POST'.  -- I think there is a previous Pull Request with this change by evandekieft 
3. While revising how to implement authentication with Linkedin, I noticed that the documentation on http://developer.linkedin.com/documents/authentication stated that the authorize url is: https//www.linkedin.com/uas/oauth/authenticate?oauth_token=XXXXXXXXX. I also notice a very  strange behavior when using the aus/oauth/authorize link, it kept asking me to "Allow access" even though I had given access rights to the application. After switching to the url specified in documentation, I was requested to "Allow access" once, and thereafter, it would just redirect me to the correct authenticated callback url stated in the application callback url field.

Thanks,
-e
